### PR TITLE
fix: Cache access token locally

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(name='tap-outbrain',
           'singer-python==0.2.1',
           'backoff==1.3.2',
           'requests==2.12.4',
-          'python-dateutil==2.6.0'
+          'python-dateutil==2.6.0',
+          'platformdirs==4.0.0',
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
Caches access tokens for up to 30 days to work around rate limits imposed on the `/login` endpoint:

> Authentication requests to obtain token (`/login`) limited to 2 requests per hour per user.

> Given the limitation on `/login` requests, the recommended way to manage tokens is to store an active token to be used in all requests, and periodically update it. Since each token is valid for 30 days, the update period should be 30 days or less.

https://amplifyv01.docs.apiary.io/#reference/rate-limits