### PR TITLE
fix: Remove enforced limit of 2 reporting requests per minute

### DIFF
--- a/tap_outbrain/__init__.py
+++ b/tap_outbrain/__init__.py
@@ -231,15 +231,6 @@ def sync_performance(state, access_token, account_id, table_name, state_sub_id,
 
         from_date = new_from_date
 
-        if last_request_start is not None and \
-           (time.time() - last_request_end) < 30:
-            to_sleep = 30 - (time.time() - last_request_end)
-            logger.info(
-                'Limiting to 2 requests per minute. Sleeping {} sec '
-                'before making the next reporting request.'
-                .format(to_sleep))
-            time.sleep(to_sleep)
-
 
 def parse_campaign(campaign):
     if campaign.get('budget') is not None:


### PR DESCRIPTION
No such limit exists in the API (any longer?)

> Each marketer is limited to 10 requests per minute for the entire performance reporting API. In case of rate limit violation the response status will be 429 (Too Many Requests).

https://amplifyv01.docs.apiary.io/#reference/performance-reporting/retrieve-periodic-performance-statistics-for-a-marketer

Existing backoff implementation should cover any 429 errors